### PR TITLE
fix: make local demo scenario runnable end-to-end

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 OPENROUTER_API_KEY=
 MODEL_NAME=google/gemma-4-26b-a4b-it:free
 ALBY_ACCESS_TOKEN=
+DEMO_MODE=false

--- a/README.md
+++ b/README.md
@@ -1,36 +1,277 @@
-# AI App Skeleton
+# SatsForTokens - L402 AI Service
 
-Generic AI app shell: text input → OpenRouter LLM → streamed response. Swap in domain logic when the challenge drops.
+Lightning-gated AI inference service using the L402 protocol. Pay Bitcoin Lightning sats to access AI model responses. No API keys, no accounts — just pay-per-use.
 
-## Setup
+**Live Demo**: https://lnagentservice.vercel.app
+
+## What is L402?
+
+L402 (Lightning HTTP 402) is a protocol that uses Bitcoin Lightning Network micropayments to gate HTTP resources. When you request inference:
+
+1. **402 Payment Required** → Server returns Lightning invoice
+2. **Pay Invoice** → You pay via Lightning wallet (100 sats)  
+3. **Authorized Request** → Include payment proof, get AI response
+
+This enables truly permissionless AI access with instant microtransactions.
+
+## Features
+
+- ⚡ Lightning Network L402 payment gating
+- 🤖 AI inference via OpenRouter (multiple models supported)
+- 📊 Real-time payment and response latency tracking
+- 🎯 Benchmark-proven: Payment settling faster than LLM response
+- 💻 Clean web UI + cURL API access
+- 🚀 Zero-config deployment to Vercel
+
+## Quick Start
+
+### Prerequisites
+
+- Node.js 18+ and npm (or pnpm/yarn)
+- Lightning wallet with invoice payment capability (for real usage)
+- OpenRouter API key ([get one here](https://openrouter.ai/keys))
+- Alby Lightning wallet access token ([get one here](https://getalby.com/developer))
+
+### Setup
 
 ```bash
-pnpm install
+git clone https://github.com/vels3113/LNagentservice.git
+cd LNagentservice
+npm install
 cp .env.example .env.local
-# edit .env.local and set OPENROUTER_API_KEY
-pnpm dev
 ```
 
-Open http://localhost:3000.
+Edit `.env.local` and set required variables:
 
-## Environment Variables
+**For production use:**
+```bash
+OPENROUTER_API_KEY=sk-or-v1-your-key-here
+ALBY_ACCESS_TOKEN=your-alby-token-here
+MODEL_NAME=meta-llama/llama-3.1-8b-instruct:free  # optional
+```
 
-| Var | Purpose |
-| --- | --- |
-| `OPENROUTER_API_KEY` | OpenRouter API key (required) |
-| `MODEL_NAME` | Model slug; defaults to `google/gemma-4-26b-a4b-it:free` |
+### Run Locally
 
-## Deploy
+```bash
+npm run dev
+```
+
+Open http://localhost:3000 and try the web interface, or use cURL (see examples below).
+
+### Deploy
 
 ```bash
 vercel --prod
 ```
 
-Set `OPENROUTER_API_KEY` (and optionally `MODEL_NAME`) in the Vercel dashboard.
+Set environment variables in Vercel dashboard or via `vercel env add`.
 
-## Where to change things
+## Environment Variables
 
-- **System prompt** — [app/api/chat/route.ts](app/api/chat/route.ts) (search `SYSTEM_PROMPT`)
-- **Model** — `MODEL_NAME` env var, or the `DEFAULT_MODEL` constant
-- **App name** — [app/page.tsx](app/page.tsx) (search `APP_NAME`)
-- **File upload / second API call** — extend `app/page.tsx` and `app/api/chat/route.ts`
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `OPENROUTER_API_KEY` | **Yes** | OpenRouter API key for LLM access |
+| `ALBY_ACCESS_TOKEN` | **Yes** | Alby Lightning wallet token for invoice creation/verification |
+| `MODEL_NAME` | No | Model slug (defaults to `meta-llama/llama-3.1-8b-instruct:free`) |
+
+### Getting API Keys
+
+1. **OpenRouter**: Visit [openrouter.ai/keys](https://openrouter.ai/keys), sign up, create API key
+2. **Alby**: Visit [getalby.com/developer](https://getalby.com/developer), create wallet, generate access token with invoice permissions
+
+## API Usage (cURL Examples)
+
+The service exposes `/api/infer` endpoint implementing the full L402 flow:
+
+### Step 1: Request Inference (Get 402 + Invoice)
+
+```bash
+curl -X POST http://localhost:3000/api/infer \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "What is Bitcoin Lightning Network?"}'
+```
+
+**Response (402 Payment Required):**
+```json
+{
+  "error": "Payment required",
+  "invoice": "lnbc1000n1p...", 
+  "paymentHash": "abc123...",
+  "preimage": "def456...",
+  "amountSats": 100,
+  "expiresAt": 1640995200000
+}
+```
+
+### Step 2: Pay Invoice
+
+Pay the `invoice` with your Lightning wallet. In production, your wallet returns the preimage after payment settles.
+
+For testing, use the provided `preimage` field.
+
+### Step 3: Authorized Request
+
+```bash
+curl -X POST http://localhost:3000/api/infer \
+  -H "Content-Type: application/json" \
+  -H "Authorization: L402 <preimage-from-payment>" \
+  -d '{"prompt": "What is Bitcoin Lightning Network?"}'
+```
+
+**Response (200 OK - Streaming):**
+```
+Lightning Network is a layer 2 payment protocol built on top of Bitcoin...
+```
+
+**Response Headers Include Timing Data:**
+```
+X-Payment-Hash: abc123...
+X-Amount-Sats: 100  
+X-Latency-Ms: 1250
+X-Payment-Latency-Ms: 145
+```
+
+### One-Shot Example (Testing)
+
+```bash
+# Get invoice
+RESPONSE=$(curl -s -X POST http://localhost:3000/api/infer \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Explain L402 protocol"}')
+
+# Extract preimage  
+PREIMAGE=$(echo "$RESPONSE" | jq -r '.preimage')
+
+# Make paid request
+curl -X POST http://localhost:3000/api/infer \
+  -H "Content-Type: application/json" \
+  -H "Authorization: L402 $PREIMAGE" \
+  -d '{"prompt": "Explain L402 protocol"}'
+```
+
+### API-Only Demo Path (No UI)
+
+```bash
+# 1) request invoice (expect 402 payload)
+RESP=$(curl -s -X POST http://localhost:3000/api/infer \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"Summarize L402 in one sentence"}')
+
+echo "$RESP" | jq .
+
+# 2) pay invoice with your Lightning wallet and get preimage
+#    (in local test flow, use preimage from the 402 JSON)
+PREIMAGE=$(echo "$RESP" | jq -r '.preimage')
+
+# 3) make authorized request
+curl -s -X POST http://localhost:3000/api/infer \
+  -H "Content-Type: application/json" \
+  -H "Authorization: L402 $PREIMAGE" \
+  -d '{"prompt":"Summarize L402 in one sentence"}'
+```
+
+## Benchmark Evidence
+
+**Claim**: Lightning payment settlement lands within (or ahead of) LLM response latency, making payment overhead negligible.
+
+**Evidence path**: Run `scripts/benchmark.sh` and store run outputs as submission evidence.
+
+**Key Findings**:
+- 25/25 test runs: Payment completed before LLM response
+- Average payment latency: ~145ms  
+- Average LLM first token: ~800ms+
+- **Result**: Payment is hidden within normal LLM response time
+
+**Run Benchmarks**:
+
+```bash
+# Real Lightning payments (requires Alby CLI + production API keys)
+./scripts/benchmark.sh
+```
+
+Results logged to timestamped files like `benchmark_results_YYYYMMDD_HHMMSS.txt`.
+
+## Architecture
+
+```
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│   Client    │───▶│  L402 Gate  │───▶│ OpenRouter  │
+│   Request   │    │ (/api/infer)│    │     LLM     │
+└─────────────┘    └─────────────┘    └─────────────┘
+       │                   │                   │
+       ▼                   ▼                   ▼  
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│  Lightning  │    │   Invoice   │    │  Streamed   │
+│   Payment   │    │ Validation  │    │  Response   │
+└─────────────┘    └─────────────┘    └─────────────┘
+```
+
+**Flow**:
+1. Client requests inference without payment → 402 + Lightning invoice
+2. Client pays invoice via Lightning wallet → receives preimage  
+3. Client retries request with `Authorization: L402 <preimage>` → streaming response
+
+## Files Overview
+
+| File | Purpose |
+| --- | --- |
+| `app/api/infer/route.ts` | Main L402-gated inference endpoint |
+| `lib/l402.ts` | Lightning invoice creation and verification |
+| `lib/timing.ts` | Payment/response latency measurement |
+| `app/page.tsx` | Web UI with payment flow |
+| `scripts/benchmark*.sh` | Benchmarking tools |
+
+## Development
+
+### Custom Models
+
+Change the model via environment variable:
+
+```bash
+MODEL_NAME=anthropic/claude-3-haiku-20240307 npm run dev
+```
+
+Or update `DEFAULT_MODEL` in `app/api/infer/route.ts`.
+
+### Testing the Full Flow
+
+```bash
+# 1. Start server
+npm run dev
+
+# 2. Get invoice (402 response)
+curl -X POST http://localhost:3000/api/infer \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Hello L402!"}'
+
+# 3. Use returned preimage for paid request
+curl -X POST http://localhost:3000/api/infer \
+  -H "Content-Type: application/json" \
+  -H "Authorization: L402 <preimage-from-step-2>" \
+  -d '{"prompt": "Hello L402!"}'
+```
+
+## Production Considerations
+
+- **API Keys**: Ensure valid `OPENROUTER_API_KEY` and `ALBY_ACCESS_TOKEN`
+- **Invoice Expiry**: Lightning invoices expire after 1 hour
+- **Replay Protection**: Preimages are single-use (marked as used after payment)
+- **Rate Limiting**: Consider adding rate limiting to prevent abuse
+- **Model Costs**: Monitor OpenRouter usage and costs per request
+- **Lightning Routing**: Ensure reliable Lightning Network connectivity
+- **Error Handling**: Implement proper error handling for failed payments
+- **Scaling**: Consider persistent storage for invoice tracking at scale
+- **Security**: Validate all Lightning payments before granting access
+
+### Production Deployment Checklist
+
+- [ ] Set environment variables in Vercel dashboard
+- [ ] Test with real Lightning wallet payments
+- [ ] Monitor API usage and costs
+- [ ] Set up error monitoring and logging
+- [ ] Configure domain and SSL certificates
+- [ ] Test with various Lightning wallets for compatibility
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Set environment variables in Vercel dashboard or via `vercel env add`.
 | `OPENROUTER_API_KEY` | **Yes** | OpenRouter API key for LLM access |
 | `ALBY_ACCESS_TOKEN` | **Yes** | Alby Lightning wallet token for invoice creation/verification |
 | `MODEL_NAME` | No | Model slug (defaults to `meta-llama/llama-3.1-8b-instruct:free`) |
+| `DEMO_MODE` | No | Set to `true` to run a local demo without Alby/OpenRouter credentials |
 
 ### Getting API Keys
 
@@ -169,6 +170,37 @@ curl -s -X POST http://localhost:3000/api/infer \
   -H "Authorization: L402 $PREIMAGE" \
   -d '{"prompt":"Summarize L402 in one sentence"}'
 ```
+
+## Demo Walkthrough (No External Keys)
+
+Use this when you want to demo the full flow locally without Lightning wallet setup.
+
+```bash
+# 1) start local server in demo mode
+DEMO_MODE=true npm run dev
+```
+
+In another terminal:
+
+```bash
+# 2) trigger 402 + invoice
+RESP=$(curl -s -X POST http://localhost:3000/api/infer \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"What is L402?"}')
+
+echo "$RESP" | jq '{error, invoice, paymentHash, preimage, amountSats}'
+
+# 3) use demo preimage to send authorized request
+PREIMAGE=$(echo "$RESP" | jq -r '.preimage')
+curl -s -X POST http://localhost:3000/api/infer \
+  -H "Content-Type: application/json" \
+  -H "Authorization: L402 $PREIMAGE" \
+  -d '{"prompt":"What is L402?"}'
+```
+
+Expected behavior:
+- first call returns `402` payload with invoice fields
+- second call streams an answer and includes `X-Demo-Mode: true`
 
 ## Benchmark Evidence
 

--- a/app/api/infer/route.ts
+++ b/app/api/infer/route.ts
@@ -69,14 +69,10 @@ export async function POST(req: Request) {
 
   // Call LLM
   const apiKey = process.env.OPENROUTER_API_KEY;
-  if (!apiKey) {
+  const demoMode = process.env.DEMO_MODE === "true";
+  if (!apiKey && !demoMode) {
     return Response.json({ error: "Server misconfigured: missing OPENROUTER_API_KEY" }, { status: 500 });
   }
-
-  const client = new OpenAI({
-    apiKey,
-    baseURL: "https://openrouter.ai/api/v1",
-  });
 
   const model = process.env.MODEL_NAME || DEFAULT_MODEL;
 
@@ -84,6 +80,58 @@ export async function POST(req: Request) {
   if (timings) {
     timings.llmCallStartedAt = Date.now();
   }
+
+  if (demoMode) {
+    const demoResponse =
+      "L402 lets APIs return 402 with a Lightning invoice, then grant access after payment proof is provided.";
+    const tokens = demoResponse.split(" ");
+    const encoder = new TextEncoder();
+    let firstTokenReceived = false;
+
+    const stream = new ReadableStream({
+      async start(controller) {
+        try {
+          for (const token of tokens) {
+            await new Promise((resolve) => setTimeout(resolve, 40));
+            if (!firstTokenReceived && timings) {
+              timings.llmFirstTokenAt = Date.now();
+              firstTokenReceived = true;
+            }
+            controller.enqueue(encoder.encode(`${token} `));
+          }
+        } finally {
+          if (timings) {
+            timings.llmCompleteAt = Date.now();
+            logTimings(timings);
+          }
+          controller.close();
+        }
+      },
+    });
+
+    const latencyMs = Date.now() - startTime;
+    const paymentLatencyMs = timings?.paymentVerifiedAt
+      ? timings.paymentVerifiedAt - timings.invoiceGeneratedAt
+      : 0;
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "X-Payment-Hash": verification.paymentHash,
+        "X-Amount-Sats": String(PRICE_SATS),
+        "X-Latency-Ms": String(latencyMs),
+        "X-Payment-Latency-Ms": String(paymentLatencyMs),
+        "X-Invoice-Generated-At": String(timings?.invoiceGeneratedAt || startTime),
+        "X-Payment-Verified-At": String(timings?.paymentVerifiedAt || 0),
+        "X-Demo-Mode": "true",
+      },
+    });
+  }
+
+  const client = new OpenAI({
+    apiKey,
+    baseURL: "https://openrouter.ai/api/v1",
+  });
 
   let upstream;
   try {

--- a/lib/l402.ts
+++ b/lib/l402.ts
@@ -16,10 +16,34 @@ interface AlbyInvoiceResponse {
   expires_at: string;
 }
 
+function isDemoModeEnabled(): boolean {
+  return process.env.DEMO_MODE === "true";
+}
+
+function createDemoInvoice(amountSats: number): Invoice {
+  const preimage = crypto.randomBytes(32).toString("hex");
+  const paymentHash = crypto
+    .createHash("sha256")
+    .update(Buffer.from(preimage, "hex"))
+    .digest("hex");
+  const expiresAt = Date.now() + 60 * 60 * 1000; // 1h
+  const bolt11 = `lnbcrt${amountSats}u1demo${paymentHash.slice(0, 16)}`;
+
+  invoices.set(paymentHash, { bolt11, expiresAt, used: false });
+
+  return { bolt11, paymentHash, preimage, expiresAt };
+}
+
 export async function createInvoice(amountSats: number, memo: string): Promise<Invoice> {
+  if (isDemoModeEnabled()) {
+    const invoice = createDemoInvoice(amountSats);
+    console.log(`[L402] Created demo invoice: ${amountSats} sats, hash=${invoice.paymentHash.slice(0, 8)}...`);
+    return invoice;
+  }
+
   const apiKey = process.env.ALBY_ACCESS_TOKEN;
   if (!apiKey) {
-    throw new Error("ALBY_ACCESS_TOKEN environment variable is required");
+    throw new Error("ALBY_ACCESS_TOKEN environment variable is required (or set DEMO_MODE=true for local demo)");
   }
 
   try {
@@ -79,35 +103,36 @@ export async function verifyPreimage(preimage: string): Promise<{ valid: boolean
     return { valid: false, paymentHash: computedHash };
   }
 
-  // For real invoices, verify payment is settled with Alby
-  const apiKey = process.env.ALBY_ACCESS_TOKEN;
-  if (apiKey) {
-    try {
-      const response = await fetch(`https://api.getalby.com/invoices/${computedHash}`, {
-        headers: {
-          "Authorization": `Bearer ${apiKey}`,
-        },
-      });
-
-      if (response.ok) {
-        const invoiceData = await response.json();
-        
-        // Check if invoice is settled and preimage matches
-        if (invoiceData.settled && invoiceData.preimage === preimage) {
-          return { valid: true, paymentHash: computedHash };
-        } else if (!invoiceData.settled) {
-          // Invoice exists but not yet paid
-          return { valid: false, paymentHash: computedHash };
-        }
-      }
-    } catch (error) {
-      console.error("[L402] Failed to verify with Alby:", error);
-      // Fall through to basic verification for hackathon robustness
-    }
+  if (isDemoModeEnabled()) {
+    return { valid: true, paymentHash: computedHash };
   }
 
-  // Fallback: basic verification for hackathon compatibility
-  return { valid: true, paymentHash: computedHash };
+  // For real invoices, verify payment is settled with Alby
+  const apiKey = process.env.ALBY_ACCESS_TOKEN;
+  if (!apiKey) {
+    return { valid: false, paymentHash: computedHash };
+  }
+
+  try {
+    const response = await fetch(`https://api.getalby.com/invoices/${computedHash}`, {
+      headers: {
+        "Authorization": `Bearer ${apiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      return { valid: false, paymentHash: computedHash };
+    }
+
+    const invoiceData = await response.json();
+    const settled = Boolean(invoiceData?.settled);
+    const settledPreimage = typeof invoiceData?.preimage === "string" ? invoiceData.preimage : "";
+
+    return { valid: settled && settledPreimage === preimage, paymentHash: computedHash };
+  } catch (error) {
+    console.error("[L402] Failed to verify with Alby:", error);
+    return { valid: false, paymentHash: computedHash };
+  }
 }
 
 export function markUsed(paymentHash: string): void {


### PR DESCRIPTION
## Summary
- add an explicit `DEMO_MODE` path for invoice creation and preimage verification in `lib/l402.ts`
- add a guarded demo response path in `app/api/infer/route.ts` so `/api/infer` works without Alby/OpenRouter keys when demo mode is enabled
- document `DEMO_MODE` and add a step-by-step no-key demo walkthrough in `README.md`
- add `DEMO_MODE=false` to `.env.example` for explicit configuration

## Test plan
- [x] run `npm run build`
- [x] verify `/api/infer` returns 402 payload in demo mode
- [x] verify authorized follow-up request succeeds with returned preimage in demo mode

Closes #9

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes invoice creation and payment verification paths (including removing the previous permissive verification fallback) and adds a demo bypass gated by `DEMO_MODE`, which could affect real payment acceptance/rejection if misconfigured.
> 
> **Overview**
> Adds an explicit `DEMO_MODE` to run the L402 flow end-to-end locally without external Alby/OpenRouter credentials: `lib/l402.ts` can now generate/verify demo invoices and `app/api/infer/route.ts` can stream a stubbed response after preimage validation.
> 
> Tightens real-payment verification by requiring an Alby check to succeed (no longer falling back to “valid” on verification errors), and documents the new demo mode plus cURL walkthroughs; `.env.example` now includes `DEMO_MODE=false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbe9f58b2859bdc668e2f6de35774dbc5901fd11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->