### PR TITLE
feat: implement connect-first UI and transaction surfaces

### DIFF
--- a/app/api/connect/route.ts
+++ b/app/api/connect/route.ts
@@ -1,0 +1,54 @@
+import { registerClientConnection } from "@/lib/clients";
+
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+export async function POST(req: Request) {
+  let body: {
+    displayName?: unknown;
+    clientId?: unknown;
+    agentId?: unknown;
+    walletType?: unknown;
+    walletRef?: unknown;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const displayName = String(body.displayName ?? "").trim();
+  const clientId = String(body.clientId ?? "").trim();
+  const agentId = String(body.agentId ?? "").trim();
+  const walletType = String(body.walletType ?? "").trim();
+  const walletRef = String(body.walletRef ?? "").trim();
+
+  if (!clientId || !agentId || !walletType || !walletRef) {
+    return Response.json(
+      { error: "clientId, agentId, walletType, and walletRef are required" },
+      { status: 400 }
+    );
+  }
+
+  const connection = registerClientConnection({
+    displayName,
+    clientId,
+    agentId,
+    walletType,
+    walletRef,
+  });
+
+  return Response.json(
+    {
+      connectionId: connection.connectionId,
+      displayName: connection.displayName ?? null,
+      clientId: connection.clientId,
+      agentId: connection.agentId,
+      walletType: connection.walletType,
+      walletRef: connection.walletRef,
+      createdAt: connection.createdAt,
+    },
+    { status: 200 }
+  );
+}

--- a/app/api/infer/route.ts
+++ b/app/api/infer/route.ts
@@ -1,22 +1,43 @@
 import OpenAI from "openai";
 import { createInvoice, verifyPreimage, markUsed } from "@/lib/l402";
+import { isClientConnected, isConnectionIdValid } from "@/lib/clients";
 import { createTimings, logTimings, type InferenceTimings } from "@/lib/timing";
+import { upsertTransaction } from "@/lib/transactions";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
 
 const DEFAULT_MODEL = "meta-llama/llama-3.1-8b-instruct:free";
-const PRICE_SATS = 100;
+const DEFAULT_PRICE_SATS = 100;
+
+const MODEL_PRICE_SATS: Record<string, number> = {
+  "meta-llama/llama-3.1-8b-instruct:free": 100,
+  "google/gemma-4-26b-a4b-it:free": 120,
+  "anthropic/claude-3-haiku-20240307": 300,
+};
+
+function getPriceSatsForModel(model: string): number {
+  return MODEL_PRICE_SATS[model] ?? DEFAULT_PRICE_SATS;
+}
 
 export async function POST(req: Request) {
   const startTime = Date.now();
   let timings: InferenceTimings | null = null;
+  const demoMode = process.env.DEMO_MODE === "true";
 
   // Parse body
   let prompt: string;
+  let clientId: string;
+  let agentId: string;
+  let connectionId: string;
+  let requestedModel: string;
   try {
     const body = await req.json();
     prompt = String(body?.prompt ?? "").trim();
+    clientId = String(body?.clientId ?? "").trim();
+    agentId = String(body?.agentId ?? "").trim();
+    connectionId = String(body?.connectionId ?? "").trim();
+    requestedModel = String(body?.model ?? "").trim();
   } catch {
     return Response.json({ error: "Invalid JSON body" }, { status: 400 });
   }
@@ -25,26 +46,64 @@ export async function POST(req: Request) {
     return Response.json({ error: "Prompt is required" }, { status: 400 });
   }
 
+  if (!clientId || !agentId) {
+    return Response.json(
+      { error: "clientId and agentId are required. Connect first via /api/connect." },
+      { status: 400 }
+    );
+  }
+
+  // Accept either in-memory registration or a valid signed connection id.
+  const isConnected = isClientConnected(clientId, agentId);
+  const hasValidConnectionId = isConnectionIdValid(connectionId, clientId, agentId);
+  const isLocalDemoPair = demoMode && clientId === "demo-client" && agentId === "demo-agent";
+  if (!isConnected && !hasValidConnectionId && !isLocalDemoPair) {
+    return Response.json(
+      {
+        error:
+          "Client/agent pair is not connected. Call /api/connect first and include connectionId in /api/infer.",
+      },
+      { status: 403 }
+    );
+  }
+
+  const model = requestedModel || process.env.MODEL_NAME || DEFAULT_MODEL;
+  const priceSats = getPriceSatsForModel(model);
+
   // Check for L402 Authorization header
   const authHeader = req.headers.get("Authorization");
   const l402Match = authHeader?.match(/^L402\s+(\S+)$/i);
 
   if (!l402Match) {
     // No payment — return 402 with invoice
-    const invoice = await createInvoice(PRICE_SATS, `SatsForTokens: ${prompt.slice(0, 50)}`);
+    const invoice = await createInvoice(priceSats, `SatsForTokens: ${prompt.slice(0, 50)}`);
     
     // Initialize timing tracking
-    timings = createTimings(invoice.paymentHash);
+    timings = createTimings(invoice.paymentHash, { clientId, agentId, model });
+    upsertTransaction({
+      paymentHash: invoice.paymentHash,
+      clientId,
+      agentId,
+      model,
+      amountSats: priceSats,
+      status: "pending",
+      invoiceCreatedAt: timings.invoiceGeneratedAt,
+    });
     
+    const challengePayload: Record<string, unknown> = {
+      error: "Payment required",
+      invoice: invoice.bolt11,
+      paymentHash: invoice.paymentHash,
+      amountSats: priceSats,
+      model,
+      expiresAt: invoice.expiresAt,
+    };
+    if (demoMode) {
+      challengePayload.preimage = invoice.preimage;
+    }
+
     return Response.json(
-      {
-        error: "Payment required",
-        invoice: invoice.bolt11,
-        paymentHash: invoice.paymentHash,
-        preimage: invoice.preimage, // Include for stub testing
-        amountSats: PRICE_SATS,
-        expiresAt: invoice.expiresAt,
-      },
+      challengePayload,
       {
         status: 402,
         headers: { "WWW-Authenticate": `L402 invoice="${invoice.bolt11}"` },
@@ -57,24 +116,52 @@ export async function POST(req: Request) {
   const verification = await verifyPreimage(preimage);
 
   if (!verification.valid) {
+    const replayBlocked = verification.reason === "already_used";
+    console.log(
+      JSON.stringify({
+        client_id: clientId,
+        agent_id: agentId,
+        payment_hash: verification.paymentHash || null,
+        replay_blocked: replayBlocked,
+        verification_reason: verification.reason ?? "invalid",
+      })
+    );
+    if (verification.paymentHash) {
+      upsertTransaction({
+        paymentHash: verification.paymentHash,
+        clientId,
+        agentId,
+        model,
+        amountSats: priceSats,
+        status: verification.reason === "expired" ? "expired" : "failed",
+        replayBlocked,
+        errorReason: verification.reason,
+      });
+    }
     return Response.json({ error: "Invalid or expired payment" }, { status: 401 });
   }
 
   // Initialize timings for paid request
-  timings = createTimings(verification.paymentHash);
+  timings = createTimings(verification.paymentHash, { clientId, agentId, model });
   timings.paymentVerifiedAt = Date.now();
+  upsertTransaction({
+    paymentHash: verification.paymentHash,
+    clientId,
+    agentId,
+    model,
+    amountSats: priceSats,
+    status: "paid",
+    paymentVerifiedAt: timings.paymentVerifiedAt,
+  });
 
   // Mark as used (prevent replay)
   markUsed(verification.paymentHash);
 
   // Call LLM
   const apiKey = process.env.OPENROUTER_API_KEY;
-  const demoMode = process.env.DEMO_MODE === "true";
   if (!apiKey && !demoMode) {
     return Response.json({ error: "Server misconfigured: missing OPENROUTER_API_KEY" }, { status: 500 });
   }
-
-  const model = process.env.MODEL_NAME || DEFAULT_MODEL;
 
   // Start LLM request timing
   if (timings) {
@@ -103,6 +190,17 @@ export async function POST(req: Request) {
           if (timings) {
             timings.llmCompleteAt = Date.now();
             logTimings(timings);
+            upsertTransaction({
+              paymentHash: verification.paymentHash,
+              clientId,
+              agentId,
+              model,
+              amountSats: priceSats,
+              status: "completed",
+              inferenceCompletedAt: timings.llmCompleteAt,
+              latencyMs: Date.now() - startTime,
+              replayBlocked: false,
+            });
           }
           controller.close();
         }
@@ -118,7 +216,7 @@ export async function POST(req: Request) {
       headers: {
         "Content-Type": "text/plain; charset=utf-8",
         "X-Payment-Hash": verification.paymentHash,
-        "X-Amount-Sats": String(PRICE_SATS),
+        "X-Amount-Sats": String(priceSats),
         "X-Latency-Ms": String(latencyMs),
         "X-Payment-Latency-Ms": String(paymentLatencyMs),
         "X-Invoice-Generated-At": String(timings?.invoiceGeneratedAt || startTime),
@@ -145,6 +243,15 @@ export async function POST(req: Request) {
     });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : "LLM request failed";
+    upsertTransaction({
+      paymentHash: verification.paymentHash,
+      clientId,
+      agentId,
+      model,
+      amountSats: priceSats,
+      status: "failed",
+      errorReason: message,
+    });
     return Response.json({ error: message }, { status: 502 });
   }
 
@@ -174,6 +281,17 @@ export async function POST(req: Request) {
         if (timings) {
           timings.llmCompleteAt = Date.now();
           logTimings(timings);
+          upsertTransaction({
+            paymentHash: verification.paymentHash,
+            clientId,
+            agentId,
+            model,
+            amountSats: priceSats,
+            status: "completed",
+            inferenceCompletedAt: timings.llmCompleteAt,
+            latencyMs: Date.now() - startTime,
+            replayBlocked: false,
+          });
         }
         controller.close();
       }
@@ -191,7 +309,7 @@ export async function POST(req: Request) {
     headers: {
       "Content-Type": "text/plain; charset=utf-8",
       "X-Payment-Hash": verification.paymentHash,
-      "X-Amount-Sats": String(PRICE_SATS),
+      "X-Amount-Sats": String(priceSats),
       "X-Latency-Ms": String(latencyMs),
       "X-Payment-Latency-Ms": String(paymentLatencyMs),
       "X-Invoice-Generated-At": String(timings?.invoiceGeneratedAt || startTime),

--- a/app/api/resources/route.ts
+++ b/app/api/resources/route.ts
@@ -1,0 +1,82 @@
+import {
+  addClientResource,
+  isClientConnected,
+  isConnectionIdValid,
+  listClientResources,
+} from "@/lib/clients";
+
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+function canAccess(clientId: string, agentId: string, connectionId: string): boolean {
+  return isClientConnected(clientId, agentId) || isConnectionIdValid(connectionId, clientId, agentId);
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const clientId = (url.searchParams.get("clientId") || "").trim();
+  const agentId = (url.searchParams.get("agentId") || "").trim();
+  const connectionId = (url.searchParams.get("connectionId") || "").trim();
+
+  if (!clientId || !agentId) {
+    return Response.json({ error: "clientId and agentId are required" }, { status: 400 });
+  }
+
+  if (!canAccess(clientId, agentId, connectionId)) {
+    return Response.json({ error: "Client/agent pair is not connected" }, { status: 403 });
+  }
+
+  return Response.json({ resources: listClientResources(clientId, agentId) }, { status: 200 });
+}
+
+export async function POST(req: Request) {
+  let body: {
+    clientId?: unknown;
+    agentId?: unknown;
+    connectionId?: unknown;
+    title?: unknown;
+    resourceType?: unknown;
+    value?: unknown;
+  };
+
+  try {
+    body = await req.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const clientId = String(body.clientId ?? "").trim();
+  const agentId = String(body.agentId ?? "").trim();
+  const connectionId = String(body.connectionId ?? "").trim();
+  const title = String(body.title ?? "").trim();
+  const resourceType = String(body.resourceType ?? "").trim();
+  const value = String(body.value ?? "").trim();
+
+  if (!clientId || !agentId || !title || !resourceType || !value) {
+    return Response.json(
+      { error: "clientId, agentId, title, resourceType, and value are required" },
+      { status: 400 }
+    );
+  }
+
+  if (!["prompt_template", "context_text", "reference_url"].includes(resourceType)) {
+    return Response.json(
+      { error: "resourceType must be one of prompt_template, context_text, reference_url" },
+      { status: 400 }
+    );
+  }
+
+  if (!canAccess(clientId, agentId, connectionId)) {
+    return Response.json({ error: "Client/agent pair is not connected" }, { status: 403 });
+  }
+
+  const resource = addClientResource({
+    clientId,
+    agentId,
+    title,
+    resourceType: resourceType as "prompt_template" | "context_text" | "reference_url",
+    value,
+  });
+
+  return Response.json({ resource }, { status: 200 });
+}

--- a/app/api/transactions/route.ts
+++ b/app/api/transactions/route.ts
@@ -1,0 +1,31 @@
+import { listTransactions, type TransactionStatus } from "@/lib/transactions";
+
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+const VALID_STATUSES: TransactionStatus[] = ["pending", "paid", "completed", "expired", "failed"];
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const statusParam = (url.searchParams.get("status") || "").trim();
+  const clientId = (url.searchParams.get("clientId") || "").trim();
+  const agentId = (url.searchParams.get("agentId") || "").trim();
+  const limitParam = Number(url.searchParams.get("limit") || "50");
+  const limit = Number.isFinite(limitParam) && limitParam > 0 ? Math.min(limitParam, 200) : 50;
+
+  if (statusParam && !VALID_STATUSES.includes(statusParam as TransactionStatus)) {
+    return Response.json(
+      { error: "status must be one of pending, paid, completed, expired, failed" },
+      { status: 400 }
+    );
+  }
+
+  const transactions = listTransactions({
+    status: statusParam ? (statusParam as TransactionStatus) : undefined,
+    clientId: clientId || undefined,
+    agentId: agentId || undefined,
+    limit,
+  });
+
+  return Response.json({ transactions }, { status: 200 });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import { Loader2, SendHorizonal, Zap, CheckCircle, Clock, Activity } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -21,8 +22,23 @@ interface TimingMetrics {
   streamingStarted?: number;
 }
 
+interface ConnectionData {
+  connectionId: string;
+  displayName?: string | null;
+  clientId: string;
+  agentId: string;
+  walletType: string;
+  walletRef: string;
+}
+
 export default function Home() {
   const [prompt, setPrompt] = useState("");
+  const [displayName, setDisplayName] = useState("Demo User");
+  const [clientId, setClientId] = useState("demo-client");
+  const [agentId, setAgentId] = useState("demo-agent");
+  const [walletType, setWalletType] = useState("demo");
+  const [walletRef, setWalletRef] = useState("local-wallet");
+  const [connection, setConnection] = useState<ConnectionData | null>(null);
   const [response, setResponse] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -31,9 +47,79 @@ export default function Home() {
   const [timingMetrics, setTimingMetrics] = useState<TimingMetrics | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
+  useEffect(() => {
+    const rawProfile = localStorage.getItem("sats_signup_profile");
+    if (rawProfile) {
+      try {
+        const profile = JSON.parse(rawProfile) as {
+          displayName?: string;
+          clientId?: string;
+          agentId?: string;
+          walletType?: string;
+          walletRef?: string;
+        };
+        if (profile.displayName) setDisplayName(profile.displayName);
+        if (profile.clientId) setClientId(profile.clientId);
+        if (profile.agentId) setAgentId(profile.agentId);
+        if (profile.walletType) setWalletType(profile.walletType);
+        if (profile.walletRef) setWalletRef(profile.walletRef);
+      } catch {
+        // ignore invalid local storage payload
+      }
+    }
+
+    const rawConnection = localStorage.getItem("sats_connection");
+    if (rawConnection) {
+      try {
+        const existingConnection = JSON.parse(rawConnection) as ConnectionData;
+        if (existingConnection.connectionId) {
+          setConnection(existingConnection);
+        }
+      } catch {
+        // ignore invalid local storage payload
+      }
+    }
+  }, []);
+
+  async function handleConnect() {
+    if (!displayName.trim() || !clientId.trim() || !agentId.trim() || !walletType.trim() || !walletRef.trim()) {
+      setError("displayName, clientId, agentId, walletType, and walletRef are required");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/connect", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName, clientId, agentId, walletType, walletRef }),
+      });
+
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `Connect failed (${res.status})`);
+      }
+
+      const data = await res.json();
+      setConnection(data);
+      localStorage.setItem(
+        "sats_signup_profile",
+        JSON.stringify({ displayName, clientId, agentId, walletType, walletRef })
+      );
+      localStorage.setItem("sats_connection", JSON.stringify(data));
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message || "Failed to connect");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!prompt.trim() || loading) return;
+    if (!prompt.trim() || loading || !connection) return;
 
     setLoading(true);
     setError(null);
@@ -50,7 +136,12 @@ export default function Home() {
       const res = await fetch("/api/infer", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ prompt }),
+        body: JSON.stringify({
+          prompt,
+          clientId,
+          agentId,
+          connectionId: connection.connectionId,
+        }),
         signal: controller.signal,
       });
 
@@ -82,7 +173,7 @@ export default function Home() {
   }
 
   async function handlePay() {
-    if (!invoiceData) return;
+    if (!invoiceData || !connection) return;
 
     setLoading(true);
     setError(null);
@@ -103,7 +194,12 @@ export default function Home() {
           "Content-Type": "application/json",
           Authorization: `L402 ${preimage}`,
         },
-        body: JSON.stringify({ prompt }),
+        body: JSON.stringify({
+          prompt,
+          clientId,
+          agentId,
+          connectionId: connection.connectionId,
+        }),
       });
 
       if (!res.ok || !res.body) {
@@ -169,7 +265,67 @@ export default function Home() {
         <p className="text-sm text-muted-foreground">
           L402-gated AI inference. Pay Lightning sats, get tokens. No keys. No accounts.
         </p>
+        <Link href="/signup" className="mt-2 inline-block text-xs text-muted-foreground underline">
+          New here? Complete agent-wallet signup
+        </Link>
+        <Link href="/resources" className="ml-4 mt-2 inline-block text-xs text-muted-foreground underline">
+          Open resource workspace
+        </Link>
+        <Link href="/transactions" className="ml-4 mt-2 inline-block text-xs text-muted-foreground underline">
+          Open transaction monitor
+        </Link>
       </header>
+
+      <section className="mb-4 rounded-lg border bg-muted/20 p-4">
+        <h2 className="mb-3 text-sm font-semibold">1) Connect Client + Agent + Wallet</h2>
+        <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+          <Input
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            placeholder="displayName"
+            disabled={loading}
+            aria-label="Display name"
+          />
+          <Input
+            value={clientId}
+            onChange={(e) => setClientId(e.target.value)}
+            placeholder="clientId"
+            disabled={loading}
+            aria-label="Client ID"
+          />
+          <Input
+            value={agentId}
+            onChange={(e) => setAgentId(e.target.value)}
+            placeholder="agentId"
+            disabled={loading}
+            aria-label="Agent ID"
+          />
+          <Input
+            value={walletType}
+            onChange={(e) => setWalletType(e.target.value)}
+            placeholder="walletType"
+            disabled={loading}
+            aria-label="Wallet type"
+          />
+          <Input
+            value={walletRef}
+            onChange={(e) => setWalletRef(e.target.value)}
+            placeholder="walletRef"
+            disabled={loading}
+            aria-label="Wallet reference"
+          />
+        </div>
+        <div className="mt-3 flex items-center gap-2">
+          <Button type="button" onClick={handleConnect} disabled={loading}>
+            {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : "Connect"}
+          </Button>
+          {connection && (
+            <p className="text-xs text-emerald-700">
+              Connected{connection.displayName ? ` (${connection.displayName})` : ""}: {connection.connectionId}
+            </p>
+          )}
+        </div>
+      </section>
 
       <form onSubmit={handleSubmit} className="flex flex-col gap-2">
         <div className="flex gap-2">
@@ -177,10 +333,13 @@ export default function Home() {
             value={prompt}
             onChange={(e) => setPrompt(e.target.value)}
             placeholder="Ask something..."
-            disabled={loading || paymentState === "awaiting_payment"}
+            disabled={loading || paymentState === "awaiting_payment" || !connection}
             aria-label="Prompt"
           />
-          <Button type="submit" disabled={loading || !prompt.trim() || paymentState === "awaiting_payment"}>
+          <Button
+            type="submit"
+            disabled={loading || !prompt.trim() || paymentState === "awaiting_payment" || !connection}
+          >
             {loading ? (
               <Loader2 className="h-4 w-4 animate-spin" />
             ) : (
@@ -290,6 +449,12 @@ export default function Home() {
           </div>
         )}
       </section>
+
+      {!connection && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Connect first to unlock paid inference flow.
+        </p>
+      )}
 
       {/* Footer */}
       <footer className="mt-8 border-t pt-4 text-center text-xs text-muted-foreground">

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+type ResourceType = "prompt_template" | "context_text" | "reference_url";
+
+interface ResourceItem {
+  resourceId: string;
+  title: string;
+  resourceType: ResourceType;
+  value: string;
+  createdAt: number;
+}
+
+export default function ResourcesPage() {
+  const [clientId, setClientId] = useState("demo-client");
+  const [agentId, setAgentId] = useState("demo-agent");
+  const [connectionId, setConnectionId] = useState("");
+  const [title, setTitle] = useState("");
+  const [resourceType, setResourceType] = useState<ResourceType>("prompt_template");
+  const [value, setValue] = useState("");
+  const [resources, setResources] = useState<ResourceItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const storedConnection = localStorage.getItem("sats_connection");
+    if (storedConnection) {
+      try {
+        const parsed = JSON.parse(storedConnection) as {
+          clientId?: string;
+          agentId?: string;
+          connectionId?: string;
+        };
+        if (parsed.clientId) setClientId(parsed.clientId);
+        if (parsed.agentId) setAgentId(parsed.agentId);
+        if (parsed.connectionId) setConnectionId(parsed.connectionId);
+      } catch {
+        // ignore malformed local storage
+      }
+    }
+  }, []);
+
+  async function fetchResources() {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ clientId, agentId, connectionId });
+      const res = await fetch(`/api/resources?${params.toString()}`);
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `Fetch failed (${res.status})`);
+      }
+      const data = await res.json();
+      setResources(data.resources ?? []);
+    } catch (err: unknown) {
+      if (err instanceof Error) setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function submitResource(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim() || !value.trim()) {
+      setError("title and value are required");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/resources", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          clientId,
+          agentId,
+          connectionId,
+          title,
+          resourceType,
+          value,
+        }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `Submit failed (${res.status})`);
+      }
+      setTitle("");
+      setValue("");
+      await fetchResources();
+    } catch (err: unknown) {
+      if (err instanceof Error) setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-2xl flex-col px-4 py-8">
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight">Resources Workspace</h1>
+        <p className="text-sm text-muted-foreground">
+          Submit metadata resources and link them to your connected client/agent pair.
+        </p>
+        <Link href="/" className="mt-2 inline-block text-xs text-muted-foreground underline">
+          Back to demo
+        </Link>
+      </header>
+
+      <section className="mb-4 rounded-lg border bg-muted/20 p-4">
+        <p className="text-xs text-muted-foreground">
+          Pair: <span className="font-mono">{clientId}</span> / <span className="font-mono">{agentId}</span>
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Connection: <span className="font-mono">{connectionId || "none"}</span>
+        </p>
+      </section>
+
+      <form onSubmit={submitResource} className="space-y-2 rounded-lg border bg-muted/20 p-4">
+        <Input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Resource title"
+          disabled={loading}
+        />
+        <select
+          value={resourceType}
+          onChange={(e) => setResourceType(e.target.value as ResourceType)}
+          className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+          disabled={loading}
+        >
+          <option value="prompt_template">prompt_template</option>
+          <option value="context_text">context_text</option>
+          <option value="reference_url">reference_url</option>
+        </select>
+        <Input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="Template / text snippet / URL"
+          disabled={loading}
+        />
+        <div className="flex gap-2">
+          <Button type="submit" disabled={loading}>
+            Submit resource
+          </Button>
+          <Button type="button" variant="outline" onClick={fetchResources} disabled={loading}>
+            Refresh
+          </Button>
+        </div>
+        {error && (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+      </form>
+
+      <section className="mt-4 space-y-2">
+        {resources.map((resource) => (
+          <article key={resource.resourceId} className="rounded-md border p-3">
+            <p className="text-sm font-medium">{resource.title}</p>
+            <p className="text-xs text-muted-foreground">{resource.resourceType}</p>
+            <p className="mt-1 break-all text-xs">{resource.value}</p>
+          </article>
+        ))}
+        {!resources.length && (
+          <p className="text-sm text-muted-foreground">
+            No resources yet. Submit one and refresh.
+          </p>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export default function SignupPage() {
+  const router = useRouter();
+  const [displayName, setDisplayName] = useState("");
+  const [clientId, setClientId] = useState("demo-client");
+  const [agentId, setAgentId] = useState("demo-agent");
+  const [walletType, setWalletType] = useState("demo");
+  const [walletRef, setWalletRef] = useState("local-wallet");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!displayName.trim() || !clientId.trim() || !agentId.trim() || !walletType.trim() || !walletRef.trim()) {
+      setError("All fields are required");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/connect", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          displayName,
+          clientId,
+          agentId,
+          walletType,
+          walletRef,
+        }),
+      });
+
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `Signup failed (${res.status})`);
+      }
+
+      const connection = await res.json();
+      localStorage.setItem(
+        "sats_signup_profile",
+        JSON.stringify({ displayName, clientId, agentId, walletType, walletRef })
+      );
+      localStorage.setItem("sats_connection", JSON.stringify(connection));
+
+      router.push("/");
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message || "Signup failed");
+      }
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-lg flex-col px-4 py-8">
+      <header className="mb-6">
+        <h1 className="text-2xl font-semibold tracking-tight">Agent-Wallet Signup</h1>
+        <p className="text-sm text-muted-foreground">
+          Register your profile, client, agent, and wallet metadata for paid inference.
+        </p>
+      </header>
+
+      <form onSubmit={handleSubmit} className="space-y-3 rounded-lg border bg-muted/20 p-4">
+        <Input
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          placeholder="Display name"
+          disabled={loading}
+          aria-label="Display name"
+        />
+        <Input
+          value={clientId}
+          onChange={(e) => setClientId(e.target.value)}
+          placeholder="Client ID"
+          disabled={loading}
+          aria-label="Client ID"
+        />
+        <Input
+          value={agentId}
+          onChange={(e) => setAgentId(e.target.value)}
+          placeholder="Agent ID"
+          disabled={loading}
+          aria-label="Agent ID"
+        />
+        <Input
+          value={walletType}
+          onChange={(e) => setWalletType(e.target.value)}
+          placeholder="Wallet type"
+          disabled={loading}
+          aria-label="Wallet type"
+        />
+        <Input
+          value={walletRef}
+          onChange={(e) => setWalletRef(e.target.value)}
+          placeholder="Wallet reference"
+          disabled={loading}
+          aria-label="Wallet reference"
+        />
+
+        {error && (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+
+        <Button type="submit" disabled={loading} className="w-full">
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : "Complete signup"}
+        </Button>
+      </form>
+
+      <Link href="/" className="mt-4 text-center text-sm text-muted-foreground underline">
+        Back to demo
+      </Link>
+    </main>
+  );
+}

--- a/app/transactions/page.tsx
+++ b/app/transactions/page.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+type TxStatus = "pending" | "paid" | "completed" | "expired" | "failed";
+
+interface TxRecord {
+  paymentHash: string;
+  clientId: string;
+  agentId: string;
+  model: string;
+  amountSats: number;
+  status: TxStatus;
+  invoiceCreatedAt?: number;
+  paymentVerifiedAt?: number;
+  inferenceCompletedAt?: number;
+  latencyMs?: number;
+  replayBlocked?: boolean;
+  errorReason?: string;
+}
+
+export default function TransactionsPage() {
+  const [clientId, setClientId] = useState("");
+  const [agentId, setAgentId] = useState("");
+  const [status, setStatus] = useState<"" | TxStatus>("");
+  const [rows, setRows] = useState<TxRecord[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetchRows();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function fetchRows() {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (status) params.set("status", status);
+      if (clientId.trim()) params.set("clientId", clientId.trim());
+      if (agentId.trim()) params.set("agentId", agentId.trim());
+      params.set("limit", "100");
+
+      const res = await fetch(`/api/transactions?${params.toString()}`);
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `Failed (${res.status})`);
+      }
+      const data = await res.json();
+      setRows(data.transactions ?? []);
+    } catch (err: unknown) {
+      if (err instanceof Error) setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="mx-auto min-h-screen max-w-5xl px-4 py-8">
+      <header className="mb-4">
+        <h1 className="text-2xl font-semibold tracking-tight">Transaction Monitor</h1>
+        <p className="text-sm text-muted-foreground">
+          Observe invoice to payment verification to inference completion lifecycle.
+        </p>
+        <Link href="/" className="mt-2 inline-block text-xs text-muted-foreground underline">
+          Back to demo
+        </Link>
+      </header>
+
+      <section className="mb-4 grid grid-cols-1 gap-2 rounded-lg border bg-muted/20 p-3 md:grid-cols-5">
+        <Input value={clientId} onChange={(e) => setClientId(e.target.value)} placeholder="clientId" />
+        <Input value={agentId} onChange={(e) => setAgentId(e.target.value)} placeholder="agentId" />
+        <select
+          value={status}
+          onChange={(e) => setStatus(e.target.value as "" | TxStatus)}
+          className="h-10 rounded-md border bg-background px-3 text-sm"
+        >
+          <option value="">all statuses</option>
+          <option value="pending">pending</option>
+          <option value="paid">paid</option>
+          <option value="completed">completed</option>
+          <option value="expired">expired</option>
+          <option value="failed">failed</option>
+        </select>
+        <Button type="button" onClick={fetchRows} disabled={loading}>
+          Refresh
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => {
+            setClientId("");
+            setAgentId("");
+            setStatus("");
+          }}
+          disabled={loading}
+        >
+          Clear filters
+        </Button>
+      </section>
+
+      {error && (
+        <p className="mb-3 text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+
+      <section className="overflow-auto rounded-lg border">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-muted/30 text-xs">
+            <tr>
+              <th className="px-3 py-2">Status</th>
+              <th className="px-3 py-2">Hash</th>
+              <th className="px-3 py-2">Client/Agent</th>
+              <th className="px-3 py-2">Amount</th>
+              <th className="px-3 py-2">Model</th>
+              <th className="px-3 py-2">Latency</th>
+              <th className="px-3 py-2">Replay blocked</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((tx) => (
+              <tr key={tx.paymentHash} className="border-t">
+                <td className="px-3 py-2">{tx.status}</td>
+                <td className="px-3 py-2 font-mono text-xs">{tx.paymentHash.slice(0, 12)}...</td>
+                <td className="px-3 py-2 text-xs">
+                  {tx.clientId} / {tx.agentId}
+                </td>
+                <td className="px-3 py-2">{tx.amountSats}</td>
+                <td className="px-3 py-2 text-xs">{tx.model}</td>
+                <td className="px-3 py-2">{tx.latencyMs ?? "-"}</td>
+                <td className="px-3 py-2">{tx.replayBlocked ? "yes" : "no"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {!rows.length && (
+          <p className="p-3 text-sm text-muted-foreground">No transactions found for current filters.</p>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/lib/clients.ts
+++ b/lib/clients.ts
@@ -1,0 +1,120 @@
+import crypto from "crypto";
+
+export interface ClientConnection {
+  connectionId: string;
+  displayName?: string;
+  clientId: string;
+  agentId: string;
+  walletType: string;
+  walletRef: string;
+  createdAt: number;
+}
+
+export interface ClientResource {
+  resourceId: string;
+  clientId: string;
+  agentId: string;
+  title: string;
+  resourceType: "prompt_template" | "context_text" | "reference_url";
+  value: string;
+  createdAt: number;
+}
+
+const connections = new Map<string, ClientConnection>();
+const resources = new Map<string, ClientResource[]>();
+
+function connectionKey(clientId: string, agentId: string): string {
+  return `${clientId}::${agentId}`;
+}
+
+function connectionSecret(): string {
+  return process.env.CONNECTION_SIGNING_SECRET || "dev-connection-secret";
+}
+
+function signPair(clientId: string, agentId: string): string {
+  return crypto
+    .createHmac("sha256", connectionSecret())
+    .update(connectionKey(clientId, agentId))
+    .digest("hex")
+    .slice(0, 24);
+}
+
+export function createConnectionId(clientId: string, agentId: string): string {
+  return `conn_${clientId}_${agentId}_${signPair(clientId, agentId)}`;
+}
+
+export function isConnectionIdValid(
+  connectionId: string,
+  clientId: string,
+  agentId: string
+): boolean {
+  if (!connectionId) return false;
+  const expected = createConnectionId(clientId, agentId);
+  return connectionId === expected;
+}
+
+export function registerClientConnection(input: {
+  displayName?: string;
+  clientId: string;
+  agentId: string;
+  walletType: string;
+  walletRef: string;
+}): ClientConnection {
+  const key = connectionKey(input.clientId, input.agentId);
+  const existing = connections.get(key);
+  if (existing) {
+    return existing;
+  }
+
+  const connection: ClientConnection = {
+    connectionId: createConnectionId(input.clientId, input.agentId),
+    displayName: input.displayName?.trim() || undefined,
+    clientId: input.clientId,
+    agentId: input.agentId,
+    walletType: input.walletType,
+    walletRef: input.walletRef,
+    createdAt: Date.now(),
+  };
+
+  connections.set(key, connection);
+  return connection;
+}
+
+export function getClientConnection(
+  clientId: string,
+  agentId: string
+): ClientConnection | null {
+  return connections.get(connectionKey(clientId, agentId)) ?? null;
+}
+
+export function isClientConnected(clientId: string, agentId: string): boolean {
+  return getClientConnection(clientId, agentId) !== null;
+}
+
+export function addClientResource(input: {
+  clientId: string;
+  agentId: string;
+  title: string;
+  resourceType: ClientResource["resourceType"];
+  value: string;
+}): ClientResource {
+  const key = connectionKey(input.clientId, input.agentId);
+  const resource: ClientResource = {
+    resourceId: crypto.randomUUID(),
+    clientId: input.clientId,
+    agentId: input.agentId,
+    title: input.title,
+    resourceType: input.resourceType,
+    value: input.value,
+    createdAt: Date.now(),
+  };
+
+  const current = resources.get(key) ?? [];
+  current.unshift(resource);
+  resources.set(key, current);
+  return resource;
+}
+
+export function listClientResources(clientId: string, agentId: string): ClientResource[] {
+  return resources.get(connectionKey(clientId, agentId)) ?? [];
+}

--- a/lib/l402.ts
+++ b/lib/l402.ts
@@ -86,21 +86,25 @@ export async function createInvoice(amountSats: number, memo: string): Promise<I
   }
 }
 
-export async function verifyPreimage(preimage: string): Promise<{ valid: boolean; paymentHash: string }> {
+export async function verifyPreimage(preimage: string): Promise<{
+  valid: boolean;
+  paymentHash: string;
+  reason?: "unknown_invoice" | "already_used" | "expired" | "unsettled_or_mismatch";
+}> {
   // Real L402: sha256(preimage) === paymentHash
   const computedHash = crypto.createHash("sha256").update(Buffer.from(preimage, "hex")).digest("hex");
 
   const invoice = invoices.get(computedHash);
   if (!invoice) {
-    return { valid: false, paymentHash: "" };
+    return { valid: false, paymentHash: "", reason: "unknown_invoice" };
   }
 
   if (invoice.used) {
-    return { valid: false, paymentHash: computedHash };
+    return { valid: false, paymentHash: computedHash, reason: "already_used" };
   }
 
   if (invoice.expiresAt < Date.now()) {
-    return { valid: false, paymentHash: computedHash };
+    return { valid: false, paymentHash: computedHash, reason: "expired" };
   }
 
   if (isDemoModeEnabled()) {
@@ -110,7 +114,7 @@ export async function verifyPreimage(preimage: string): Promise<{ valid: boolean
   // For real invoices, verify payment is settled with Alby
   const apiKey = process.env.ALBY_ACCESS_TOKEN;
   if (!apiKey) {
-    return { valid: false, paymentHash: computedHash };
+    return { valid: false, paymentHash: computedHash, reason: "unsettled_or_mismatch" };
   }
 
   try {
@@ -121,17 +125,21 @@ export async function verifyPreimage(preimage: string): Promise<{ valid: boolean
     });
 
     if (!response.ok) {
-      return { valid: false, paymentHash: computedHash };
+      return { valid: false, paymentHash: computedHash, reason: "unsettled_or_mismatch" };
     }
 
     const invoiceData = await response.json();
     const settled = Boolean(invoiceData?.settled);
     const settledPreimage = typeof invoiceData?.preimage === "string" ? invoiceData.preimage : "";
 
-    return { valid: settled && settledPreimage === preimage, paymentHash: computedHash };
+    if (!settled || settledPreimage !== preimage) {
+      return { valid: false, paymentHash: computedHash, reason: "unsettled_or_mismatch" };
+    }
+
+    return { valid: true, paymentHash: computedHash };
   } catch (error) {
     console.error("[L402] Failed to verify with Alby:", error);
-    return { valid: false, paymentHash: computedHash };
+    return { valid: false, paymentHash: computedHash, reason: "unsettled_or_mismatch" };
   }
 }
 

--- a/lib/timing.ts
+++ b/lib/timing.ts
@@ -1,5 +1,8 @@
 export interface InferenceTimings {
   paymentHash: string;
+  clientId?: string;
+  agentId?: string;
+  model?: string;
   invoiceGeneratedAt: number;
   paymentVerifiedAt?: number;
   llmCallStartedAt?: number;
@@ -7,8 +10,17 @@ export interface InferenceTimings {
   llmCompleteAt?: number;
 }
 
-export function createTimings(paymentHash: string): InferenceTimings {
-  return { paymentHash, invoiceGeneratedAt: Date.now() };
+export function createTimings(
+  paymentHash: string,
+  metadata?: { clientId?: string; agentId?: string; model?: string }
+): InferenceTimings {
+  return {
+    paymentHash,
+    clientId: metadata?.clientId,
+    agentId: metadata?.agentId,
+    model: metadata?.model,
+    invoiceGeneratedAt: Date.now(),
+  };
 }
 
 export function logTimings(t: InferenceTimings): void {
@@ -24,11 +36,15 @@ export function logTimings(t: InferenceTimings): void {
   console.log(
     JSON.stringify({
       payment_hash: t.paymentHash,
+      client_id: t.clientId ?? null,
+      agent_id: t.agentId ?? null,
+      model: t.model ?? null,
       lightning_ms,
       llm_first_token_ms,
       llm_full_ms,
       claim_holds,
       claim_strong,
+      replay_blocked: false,
     })
   );
 }

--- a/lib/transactions.ts
+++ b/lib/transactions.ts
@@ -1,0 +1,74 @@
+export type TransactionStatus = "pending" | "paid" | "completed" | "expired" | "failed";
+
+export interface TransactionRecord {
+  paymentHash: string;
+  clientId: string;
+  agentId: string;
+  model: string;
+  amountSats: number;
+  status: TransactionStatus;
+  invoiceCreatedAt?: number;
+  paymentVerifiedAt?: number;
+  inferenceCompletedAt?: number;
+  latencyMs?: number;
+  replayBlocked?: boolean;
+  errorReason?: string;
+}
+
+const txByHash = new Map<string, TransactionRecord>();
+
+function ensureRecord(paymentHash: string): TransactionRecord {
+  const existing = txByHash.get(paymentHash);
+  if (existing) return existing;
+  const created: TransactionRecord = {
+    paymentHash,
+    clientId: "unknown",
+    agentId: "unknown",
+    model: "unknown",
+    amountSats: 0,
+    status: "failed",
+  };
+  txByHash.set(paymentHash, created);
+  return created;
+}
+
+export function upsertTransaction(input: Partial<TransactionRecord> & { paymentHash: string }): TransactionRecord {
+  const current = ensureRecord(input.paymentHash);
+  const next: TransactionRecord = {
+    ...current,
+    ...input,
+    paymentHash: current.paymentHash,
+  };
+  txByHash.set(input.paymentHash, next);
+  return next;
+}
+
+export function listTransactions(params?: {
+  status?: TransactionStatus;
+  clientId?: string;
+  agentId?: string;
+  limit?: number;
+}): TransactionRecord[] {
+  let items = Array.from(txByHash.values());
+
+  if (params?.status) {
+    items = items.filter((tx) => tx.status === params.status);
+  }
+  if (params?.clientId) {
+    items = items.filter((tx) => tx.clientId === params.clientId);
+  }
+  if (params?.agentId) {
+    items = items.filter((tx) => tx.agentId === params.agentId);
+  }
+
+  items.sort((a, b) => {
+    const aTs = a.inferenceCompletedAt || a.paymentVerifiedAt || a.invoiceCreatedAt || 0;
+    const bTs = b.inferenceCompletedAt || b.paymentVerifiedAt || b.invoiceCreatedAt || 0;
+    return bTs - aTs;
+  });
+
+  if (params?.limit && params.limit > 0) {
+    return items.slice(0, params.limit);
+  }
+  return items;
+}


### PR DESCRIPTION
## Summary
- implement connect-first runtime and UI surfaces from active dev-plan backlog
- add signup, resources, and transactions pages with matching API routes
- enforce client/agent/connection constraints in infer flow and capture transaction lifecycle events

## Included
- `/api/connect`, `/api/resources`, `/api/transactions`
- `/signup`, `/resources`, `/transactions` pages plus home-page entry links
- `lib/clients.ts` and `lib/transactions.ts` in-memory stores
- infer route updates for connection validation, dynamic pricing, and transaction status transitions

## Test plan
- [x] run `npm run build`
- [x] smoke test connect -> infer(402) -> paid infer with connectionId
- [x] smoke test resources API submit + list
- [x] smoke test transactions API lifecycle output

Closes #16
Closes #17
Closes #18

Made with [Cursor](https://cursor.com)