### PR TITLE
docs: add closed-loop helper and integration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,49 @@ Set environment variables in Vercel dashboard or via `vercel env add`.
 
 ## API Usage (cURL Examples)
 
-The service exposes `/api/infer` endpoint implementing the full L402 flow:
+The service uses a two-step API contract:
+- `POST /api/connect` to bind `clientId + agentId + wallet metadata`
+- `POST /api/infer` to run paid inference for connected pairs
+- `POST /api/resources` + `GET /api/resources` for metadata-only resource submission by connected pairs
+
+### Step 0: Connect Client + Agent
+
+```bash
+curl -X POST http://localhost:3000/api/connect \
+  -H "Content-Type: application/json" \
+  -d '{
+    "clientId": "demo-client",
+    "agentId": "demo-agent",
+    "walletType": "demo",
+    "walletRef": "local-wallet"
+  }'
+```
+
+Expected response:
+```json
+{
+  "connectionId": "uuid",
+  "clientId": "demo-client",
+  "agentId": "demo-agent",
+  "walletType": "demo",
+  "walletRef": "local-wallet",
+  "createdAt": 1710000000000
+}
+```
+
+Then use the same `clientId`, `agentId`, and returned `connectionId` in infer requests.
 
 ### Step 1: Request Inference (Get 402 + Invoice)
 
 ```bash
 curl -X POST http://localhost:3000/api/infer \
   -H "Content-Type: application/json" \
-  -d '{"prompt": "What is Bitcoin Lightning Network?"}'
+  -d '{
+    "prompt": "What is Bitcoin Lightning Network?",
+    "clientId": "demo-client",
+    "agentId": "demo-agent",
+    "connectionId": "<connectionId-from-connect>"
+  }'
 ```
 
 **Response (402 Payment Required):**
@@ -100,9 +135,12 @@ curl -X POST http://localhost:3000/api/infer \
   "paymentHash": "abc123...",
   "preimage": "def456...",
   "amountSats": 100,
+  "model": "meta-llama/llama-3.1-8b-instruct:free",
   "expiresAt": 1640995200000
 }
 ```
+
+`amountSats` is dynamically selected by model pricing policy on the server.
 
 ### Step 2: Pay Invoice
 
@@ -116,7 +154,12 @@ For testing, use the provided `preimage` field.
 curl -X POST http://localhost:3000/api/infer \
   -H "Content-Type: application/json" \
   -H "Authorization: L402 <preimage-from-payment>" \
-  -d '{"prompt": "What is Bitcoin Lightning Network?"}'
+  -d '{
+    "prompt": "What is Bitcoin Lightning Network?",
+    "clientId": "demo-client",
+    "agentId": "demo-agent",
+    "connectionId": "<connectionId-from-connect>"
+  }'
 ```
 
 **Response (200 OK - Streaming):**
@@ -135,10 +178,15 @@ X-Payment-Latency-Ms: 145
 ### One-Shot Example (Testing)
 
 ```bash
+# connect pair first
+CONNECTION_ID=$(curl -s -X POST http://localhost:3000/api/connect \
+  -H "Content-Type: application/json" \
+  -d '{"clientId":"demo-client","agentId":"demo-agent","walletType":"demo","walletRef":"local-wallet"}' | jq -r '.connectionId')
+
 # Get invoice
 RESPONSE=$(curl -s -X POST http://localhost:3000/api/infer \
   -H "Content-Type: application/json" \
-  -d '{"prompt": "Explain L402 protocol"}')
+  -d "{\"prompt\":\"Explain L402 protocol\",\"clientId\":\"demo-client\",\"agentId\":\"demo-agent\",\"connectionId\":\"$CONNECTION_ID\"}")
 
 # Extract preimage  
 PREIMAGE=$(echo "$RESPONSE" | jq -r '.preimage')
@@ -147,16 +195,21 @@ PREIMAGE=$(echo "$RESPONSE" | jq -r '.preimage')
 curl -X POST http://localhost:3000/api/infer \
   -H "Content-Type: application/json" \
   -H "Authorization: L402 $PREIMAGE" \
-  -d '{"prompt": "Explain L402 protocol"}'
+  -d "{\"prompt\":\"Explain L402 protocol\",\"clientId\":\"demo-client\",\"agentId\":\"demo-agent\",\"connectionId\":\"$CONNECTION_ID\"}"
 ```
 
 ### API-Only Demo Path (No UI)
 
 ```bash
+# connect pair first
+CONNECTION_ID=$(curl -s -X POST http://localhost:3000/api/connect \
+  -H "Content-Type: application/json" \
+  -d '{"clientId":"demo-client","agentId":"demo-agent","walletType":"demo","walletRef":"local-wallet"}' | jq -r '.connectionId')
+
 # 1) request invoice (expect 402 payload)
 RESP=$(curl -s -X POST http://localhost:3000/api/infer \
   -H "Content-Type: application/json" \
-  -d '{"prompt":"Summarize L402 in one sentence"}')
+  -d "{\"prompt\":\"Summarize L402 in one sentence\",\"clientId\":\"demo-client\",\"agentId\":\"demo-agent\",\"connectionId\":\"$CONNECTION_ID\"}")
 
 echo "$RESP" | jq .
 
@@ -168,7 +221,14 @@ PREIMAGE=$(echo "$RESP" | jq -r '.preimage')
 curl -s -X POST http://localhost:3000/api/infer \
   -H "Content-Type: application/json" \
   -H "Authorization: L402 $PREIMAGE" \
-  -d '{"prompt":"Summarize L402 in one sentence"}'
+  -d "{\"prompt\":\"Summarize L402 in one sentence\",\"clientId\":\"demo-client\",\"agentId\":\"demo-agent\",\"connectionId\":\"$CONNECTION_ID\"}"
+```
+
+### SDK-Style Helper (Connect + Infer + Retry)
+
+```bash
+# with app running in demo mode
+BASE_URL=http://localhost:3000 bash scripts/closed-loop-demo.sh "Summarize L402"
 ```
 
 ## Demo Walkthrough (No External Keys)
@@ -183,10 +243,15 @@ DEMO_MODE=true npm run dev
 In another terminal:
 
 ```bash
+# connect pair first
+CONNECTION_ID=$(curl -s -X POST http://localhost:3000/api/connect \
+  -H "Content-Type: application/json" \
+  -d '{"clientId":"demo-client","agentId":"demo-agent","walletType":"demo","walletRef":"local-wallet"}' | jq -r '.connectionId')
+
 # 2) trigger 402 + invoice
 RESP=$(curl -s -X POST http://localhost:3000/api/infer \
   -H "Content-Type: application/json" \
-  -d '{"prompt":"What is L402?"}')
+  -d "{\"prompt\":\"What is L402?\",\"clientId\":\"demo-client\",\"agentId\":\"demo-agent\",\"connectionId\":\"$CONNECTION_ID\"}")
 
 echo "$RESP" | jq '{error, invoice, paymentHash, preimage, amountSats}'
 
@@ -195,7 +260,7 @@ PREIMAGE=$(echo "$RESP" | jq -r '.preimage')
 curl -s -X POST http://localhost:3000/api/infer \
   -H "Content-Type: application/json" \
   -H "Authorization: L402 $PREIMAGE" \
-  -d '{"prompt":"What is L402?"}'
+  -d "{\"prompt\":\"What is L402?\",\"clientId\":\"demo-client\",\"agentId\":\"demo-agent\",\"connectionId\":\"$CONNECTION_ID\"}"
 ```
 
 Expected behavior:

--- a/scripts/closed-loop-demo.sh
+++ b/scripts/closed-loop-demo.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SDK-style helper for local closed-loop flow:
+# connect -> infer (402) -> pay (demo preimage) -> paid infer
+#
+# Usage:
+#   BASE_URL=http://localhost:3000 bash scripts/closed-loop-demo.sh "Explain L402"
+
+BASE_URL="${BASE_URL:-http://localhost:3000}"
+PROMPT="${1:-Explain L402 in one sentence}"
+CLIENT_ID="${CLIENT_ID:-demo-client}"
+AGENT_ID="${AGENT_ID:-demo-agent}"
+WALLET_TYPE="${WALLET_TYPE:-demo}"
+WALLET_REF="${WALLET_REF:-local-wallet}"
+MODEL="${MODEL:-meta-llama/llama-3.1-8b-instruct:free}"
+
+echo "[1/4] Connect client+agent..."
+CONNECT_RESP="$(curl -sS -X POST "$BASE_URL/api/connect" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"clientId\":\"$CLIENT_ID\",
+    \"agentId\":\"$AGENT_ID\",
+    \"walletType\":\"$WALLET_TYPE\",
+    \"walletRef\":\"$WALLET_REF\"
+  }")"
+
+CONNECTION_ID="$(echo "$CONNECT_RESP" | jq -r '.connectionId // empty')"
+if [[ -z "$CONNECTION_ID" ]]; then
+  echo "Connect failed:"
+  echo "$CONNECT_RESP"
+  exit 1
+fi
+echo "Connected: $CONNECTION_ID"
+
+echo "[2/4] Request unpaid inference (expect 402)..."
+UNPAID_RESP="$(curl -sS -X POST "$BASE_URL/api/infer" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"prompt\":\"$PROMPT\",
+    \"clientId\":\"$CLIENT_ID\",
+    \"agentId\":\"$AGENT_ID\",
+    \"connectionId\":\"$CONNECTION_ID\",
+    \"model\":\"$MODEL\"
+  }")"
+
+PAYMENT_HASH="$(echo "$UNPAID_RESP" | jq -r '.paymentHash // empty')"
+PREIMAGE="$(echo "$UNPAID_RESP" | jq -r '.preimage // empty')"
+AMOUNT_SATS="$(echo "$UNPAID_RESP" | jq -r '.amountSats // empty')"
+
+if [[ -z "$PREIMAGE" || -z "$PAYMENT_HASH" ]]; then
+  echo "Unpaid infer did not return expected 402 payload:"
+  echo "$UNPAID_RESP"
+  exit 1
+fi
+echo "Challenge received: paymentHash=$PAYMENT_HASH amountSats=$AMOUNT_SATS"
+
+echo "[3/4] Simulate pay step (demo mode preimage)..."
+echo "Using preimage from challenge payload."
+
+echo "[4/4] Retry with L402 proof..."
+curl -sS -X POST "$BASE_URL/api/infer" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: L402 $PREIMAGE" \
+  -d "{
+    \"prompt\":\"$PROMPT\",
+    \"clientId\":\"$CLIENT_ID\",
+    \"agentId\":\"$AGENT_ID\",
+    \"connectionId\":\"$CONNECTION_ID\",
+    \"model\":\"$MODEL\"
+  }"
+echo


### PR DESCRIPTION
## Summary
- update README with active dev-plan integration contract details
- document `/api/connect` + `/api/infer` payloads with `connectionId` usage
- add `scripts/closed-loop-demo.sh` to run connect -> infer challenge -> paid retry from CLI

## Why
This isolates client integration ergonomics and README polish into a standalone docs/helper PR for easier review.

## Test plan
- [x] verify helper script is executable
- [x] validate command structure against current API contract

Closes #14
Closes #19

Made with [Cursor](https://cursor.com)