### PR TITLE
feat: harden payment proof flow and package middleware surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ curl -X POST http://localhost:3000/api/infer \
   "error": "Payment required",
   "invoice": "lnbc1000n1p...", 
   "paymentHash": "abc123...",
-  "preimage": "def456...",
   "amountSats": 100,
   "model": "meta-llama/llama-3.1-8b-instruct:free",
   "expiresAt": 1640995200000
@@ -141,12 +140,13 @@ curl -X POST http://localhost:3000/api/infer \
 ```
 
 `amountSats` is dynamically selected by model pricing policy on the server.
+`preimage` is returned only in `DEMO_MODE=true` for local testing.
 
 ### Step 2: Pay Invoice
 
 Pay the `invoice` with your Lightning wallet. In production, your wallet returns the preimage after payment settles.
 
-For testing, use the provided `preimage` field.
+For local testing (`DEMO_MODE=true`), use the provided `preimage` field from the 402 payload.
 
 ### Step 3: Authorized Request
 
@@ -266,6 +266,28 @@ curl -s -X POST http://localhost:3000/api/infer \
 Expected behavior:
 - first call returns `402` payload with invoice fields
 - second call streams an answer and includes `X-Demo-Mode: true`
+
+## Reusable Middleware Surface
+
+The core reusable interfaces for integrating L402 in other routes are:
+
+- `lib/clients.ts`
+  - `ClientConnectionInput`
+  - `registerClientConnection(input)`
+  - `isClientConnected(clientId, agentId)`
+  - `isConnectionIdValid(connectionId, clientId, agentId)`
+- `lib/l402.ts`
+  - `createInvoice(amountSats, memo)`
+  - `verifyPreimage(preimage)` returning `PaymentVerificationResult`
+  - `markUsed(paymentHash)`
+  - `PaymentVerificationReason` for explicit failure handling
+
+`app/api/infer/route.ts` demonstrates the reference middleware sequence:
+1. validate `clientId + agentId + connectionId`
+2. issue 402 challenge with invoice metadata
+3. verify payment proof (`Authorization: L402 <preimage>`)
+4. block replay with `markUsed`
+5. continue to protected resource (LLM streaming)
 
 ## Benchmark Evidence
 

--- a/app/api/infer/route.ts
+++ b/app/api/infer/route.ts
@@ -1,5 +1,10 @@
 import OpenAI from "openai";
-import { createInvoice, verifyPreimage, markUsed } from "@/lib/l402";
+import {
+  createInvoice,
+  verifyPreimage,
+  markUsed,
+  type PaymentVerificationReason,
+} from "@/lib/l402";
 import { isClientConnected, isConnectionIdValid } from "@/lib/clients";
 import { createTimings, logTimings, type InferenceTimings } from "@/lib/timing";
 import { upsertTransaction } from "@/lib/transactions";
@@ -18,6 +23,45 @@ const MODEL_PRICE_SATS: Record<string, number> = {
 
 function getPriceSatsForModel(model: string): number {
   return MODEL_PRICE_SATS[model] ?? DEFAULT_PRICE_SATS;
+}
+
+function verificationFailureResponse(reason?: PaymentVerificationReason): {
+  status: number;
+  error: string;
+  txStatus: "failed" | "expired" | "pending";
+} {
+  switch (reason) {
+    case "already_used":
+      return {
+        status: 409,
+        error: "Payment proof already consumed (replay blocked)",
+        txStatus: "failed",
+      };
+    case "expired":
+      return {
+        status: 410,
+        error: "Invoice expired. Request a new challenge.",
+        txStatus: "expired",
+      };
+    case "unknown_invoice":
+      return {
+        status: 401,
+        error: "Unknown payment proof for this invoice set",
+        txStatus: "failed",
+      };
+    case "unsettled_or_mismatch":
+      return {
+        status: 402,
+        error: "Payment not settled yet or proof mismatch",
+        txStatus: "pending",
+      };
+    default:
+      return {
+        status: 401,
+        error: "Invalid payment proof",
+        txStatus: "failed",
+      };
+  }
 }
 
 export async function POST(req: Request) {
@@ -117,6 +161,7 @@ export async function POST(req: Request) {
 
   if (!verification.valid) {
     const replayBlocked = verification.reason === "already_used";
+    const failure = verificationFailureResponse(verification.reason);
     console.log(
       JSON.stringify({
         client_id: clientId,
@@ -133,12 +178,12 @@ export async function POST(req: Request) {
         agentId,
         model,
         amountSats: priceSats,
-        status: verification.reason === "expired" ? "expired" : "failed",
+        status: failure.txStatus,
         replayBlocked,
         errorReason: verification.reason,
       });
     }
-    return Response.json({ error: "Invalid or expired payment" }, { status: 401 });
+    return Response.json({ error: failure.error }, { status: failure.status });
   }
 
   // Initialize timings for paid request

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,7 +11,7 @@ type PaymentState = "idle" | "awaiting_payment" | "paid" | "streaming" | "comple
 interface InvoiceData {
   invoice: string;
   paymentHash: string;
-  preimage: string;
+  preimage?: string;
   amountSats: number;
 }
 
@@ -44,6 +44,7 @@ export default function Home() {
   const [error, setError] = useState<string | null>(null);
   const [paymentState, setPaymentState] = useState<PaymentState>("idle");
   const [invoiceData, setInvoiceData] = useState<InvoiceData | null>(null);
+  const [paymentProof, setPaymentProof] = useState("");
   const [timingMetrics, setTimingMetrics] = useState<TimingMetrics | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
@@ -147,8 +148,9 @@ export default function Home() {
 
       if (res.status === 402) {
         // Payment required
-        const data = await res.json();
+        const data = (await res.json()) as InvoiceData;
         setInvoiceData(data);
+        setPaymentProof(data.preimage ?? "");
         setPaymentState("awaiting_payment");
         setLoading(false);
         return;
@@ -174,16 +176,16 @@ export default function Home() {
 
   async function handlePay() {
     if (!invoiceData || !connection) return;
+    if (!paymentProof.trim()) {
+      setError("Payment proof is required. In demo mode this is auto-filled.");
+      return;
+    }
 
     setLoading(true);
     setError(null);
     const payStart = Date.now();
 
     try {
-      // For stub: use the preimage we got from the 402 response
-      // In real L402: wallet pays invoice and returns preimage
-      const preimage = invoiceData.preimage;
-
       const paymentLatencyMs = Date.now() - payStart;
       setPaymentState("paid");
 
@@ -192,7 +194,7 @@ export default function Home() {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `L402 ${preimage}`,
+          Authorization: `L402 ${paymentProof.trim()}`,
         },
         body: JSON.stringify({
           prompt,
@@ -209,8 +211,6 @@ export default function Home() {
 
       // Extract timing metadata from response headers
       const totalLatencyMs = parseInt(res.headers.get("X-Latency-Ms") || "0");
-      const paymentLatencyFromServer = parseInt(res.headers.get("X-Payment-Latency-Ms") || "0");
-      
       setTimingMetrics({
         paymentMs: paymentLatencyMs,
         totalLatencyMs,
@@ -362,18 +362,30 @@ export default function Home() {
             Payment Required: {invoiceData.amountSats} sats
           </h2>
           <p className="mb-3 text-sm text-muted-foreground">
-            Pay the Lightning invoice to get your AI response.
+            Pay the Lightning invoice to get your AI response, then submit the payment proof.
           </p>
           <div className="mb-3 break-all rounded bg-muted/50 p-2 font-mono text-xs">
             {invoiceData.invoice}
           </div>
-          <Button onClick={handlePay} disabled={loading} className="w-full">
+          <Input
+            value={paymentProof}
+            onChange={(e) => setPaymentProof(e.target.value)}
+            placeholder={
+              invoiceData.preimage
+                ? "Demo proof prefilled (preimage)"
+                : "Paste wallet payment proof (preimage)"
+            }
+            className="mb-3"
+            disabled={loading}
+            aria-label="Payment proof"
+          />
+          <Button onClick={handlePay} disabled={loading || !paymentProof.trim()} className="w-full">
             {loading ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />
             ) : (
               <Zap className="mr-2 h-4 w-4" />
             )}
-            Pay {invoiceData.amountSats} sats
+            Submit payment proof ({invoiceData.amountSats} sats)
           </Button>
         </section>
       )}

--- a/lib/clients.ts
+++ b/lib/clients.ts
@@ -10,6 +10,14 @@ export interface ClientConnection {
   createdAt: number;
 }
 
+export interface ClientConnectionInput {
+  displayName?: string;
+  clientId: string;
+  agentId: string;
+  walletType: string;
+  walletRef: string;
+}
+
 export interface ClientResource {
   resourceId: string;
   clientId: string;
@@ -53,13 +61,7 @@ export function isConnectionIdValid(
   return connectionId === expected;
 }
 
-export function registerClientConnection(input: {
-  displayName?: string;
-  clientId: string;
-  agentId: string;
-  walletType: string;
-  walletRef: string;
-}): ClientConnection {
+export function registerClientConnection(input: ClientConnectionInput): ClientConnection {
   const key = connectionKey(input.clientId, input.agentId);
   const existing = connections.get(key);
   if (existing) {

--- a/lib/l402.ts
+++ b/lib/l402.ts
@@ -10,6 +10,18 @@ export interface Invoice {
   expiresAt: number;
 }
 
+export type PaymentVerificationReason =
+  | "unknown_invoice"
+  | "already_used"
+  | "expired"
+  | "unsettled_or_mismatch";
+
+export interface PaymentVerificationResult {
+  valid: boolean;
+  paymentHash: string;
+  reason?: PaymentVerificationReason;
+}
+
 interface AlbyInvoiceResponse {
   payment_request: string;
   payment_hash: string;
@@ -86,11 +98,7 @@ export async function createInvoice(amountSats: number, memo: string): Promise<I
   }
 }
 
-export async function verifyPreimage(preimage: string): Promise<{
-  valid: boolean;
-  paymentHash: string;
-  reason?: "unknown_invoice" | "already_used" | "expired" | "unsettled_or_mismatch";
-}> {
+export async function verifyPreimage(preimage: string): Promise<PaymentVerificationResult> {
   // Real L402: sha256(preimage) === paymentHash
   const computedHash = crypto.createHash("sha256").update(Buffer.from(preimage, "hex")).digest("hex");
 


### PR DESCRIPTION
## Summary
- require explicit payment proof entry in the UI for production-safe L402 flow, while still auto-prefilling in demo mode
- return reason-specific verification errors/status codes from `/api/infer` and persist matching transaction states
- export and document reusable payment middleware interfaces (`ClientConnectionInput`, `PaymentVerificationResult`, `PaymentVerificationReason`) for route reuse

## Test plan
- [x] `npm run build`
- [x] verify no lints on edited files with `ReadLints`
- [ ] manual browser check for payment-proof input on 402 screen

Closes #13
Closes #15

Made with [Cursor](https://cursor.com)